### PR TITLE
gon: remove bottle :unneeded

### DIFF
--- a/gon.rb
+++ b/gon.rb
@@ -3,7 +3,6 @@ class Gon < Formula
   desc "Sign, notarize, and package macOS CLI tools and applications written in any language."
   homepage ""
   version "0.2.3"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/mitchellh/gon/releases/download/v0.2.3/gon_macos.zip"


### PR DESCRIPTION
This syntax has been deprecated by Homebrew and is printing up deprecation warnings for users.