### PR TITLE
remove disabled homebrew directive

### DIFF
--- a/gon.rb
+++ b/gon.rb
@@ -3,7 +3,6 @@ class Gon < Formula
   desc "Sign, notarize, and package macOS CLI tools and applications written in any language."
   homepage ""
   version "0.2.3"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/mitchellh/gon/releases/download/v0.2.3/gon_macos.zip"


### PR DESCRIPTION
to resolve issues installing gon from the tap.
Running in GitHub Actions, I just started seeing errors like:
```
Error: mitchellh/gon/gon: Calling bottle :unneeded is disabled! There is no replacement.
```
when running `brew install mitchellh/gon/gon`

It appears `bottle :unneeded` has been deprecated, and was just disabled.